### PR TITLE
Make rate-limiter middleware configurable

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import { join } from 'path'
+import { NODE_ENV } from './configurations'
 import { controller } from './controllers'
 import { pageNotFound } from './controllers/404'
 import { rateLimiter, session, logger, compressor, publicMinifier, htmlMinifier } from './middlewares'
@@ -7,13 +8,16 @@ import { rateLimiter, session, logger, compressor, publicMinifier, htmlMinifier 
 const app = express()
 
 /** configurations */
-app.disable('x-powered-by')
 app.set('view engine', 'ejs')
 app.set('views', join(__dirname, '../views'))
+if (NODE_ENV === 'production') {
+  app.set('trust proxy', 1)
+  app.disable('x-powered-by')
+}
 
 /** middlewares */
 app.use(
-  rateLimiter,
+  rateLimiter(),
   session,
   logger,
   compressor,

--- a/src/middlewares/rate-limiter.ts
+++ b/src/middlewares/rate-limiter.ts
@@ -1,10 +1,23 @@
 import limiter from 'express-rate-limit'
+import type { Options } from 'express-rate-limit'
+import type { Request, Response } from 'express'
 
-const rateLimiter = limiter({
-  windowMs: 5 * 60 * 1000,
-  max: 120,
-  standardHeaders: true,
-  legacyHeaders: false
-})
+const rateLimiter = (passedOptions: Partial<Options> = {}) => {
+  return limiter({
+    windowMs: 5 * 60 * 1000,
+    max: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: async (request: Request, response: Response) => {
+      const statusCode = request.statusCode ?? 429
+      return response.status(statusCode).json({
+        statusCode,
+        message: `Cannot ${request.method} ${request.url}`,
+        error: 'Too Many Requests'
+      })
+    },
+    ...passedOptions
+  })
+}
 
 export { rateLimiter }


### PR DESCRIPTION
We might want to limit different routes with different rates, instead of using the middleware as it is, I made it returns a callback instead that has default configuration and will alter if an option is set manually.